### PR TITLE
Add `displayOrder` col to the `spots` table

### DIFF
--- a/src/main/kotlin/data/MockData.kt
+++ b/src/main/kotlin/data/MockData.kt
@@ -45,25 +45,15 @@ fun generateMockData() {
     }
 
     // Create mock parking spots
-    val spot1 = SpotEntity.new {
-        role = "regular"
-    }
+    val spot1 = SpotEntity.findById(1)!!
 
-    val spot2 = SpotEntity.new {
-        role = "regular"
-    }
+    val spot2 = SpotEntity.findById(2)!!
 
-    val spot3 = SpotEntity.new {
-        role = "admin"
-    }
+    val spot3 = SpotEntity.findById(3)!!
 
-    val spot4 = SpotEntity.new {
-        role = "handicapped"
-    }
+    val spot4 = SpotEntity.findById(4)!!
 
-    val spot5 = SpotEntity.new {
-        role = "regular"
-    }
+    val spot5 = SpotEntity.findById(5)!!
 
     // Create mock reservations
     ReservationEntity.new {

--- a/src/main/kotlin/db/spot.kt
+++ b/src/main/kotlin/db/spot.kt
@@ -5,9 +5,11 @@ import org.jetbrains.exposed.dao.id.*
 
 object SpotTable : LongIdTable("spot") {
     val role = text("role")
+    val displayOrder = integer("displayOrder")
 }
 
 class SpotEntity(id: EntityID<Long>) : LongEntity(id) {
     var role by SpotTable.role
+    var displayOrder by SpotTable.displayOrder
     companion object : LongEntityClass<SpotEntity>(SpotTable)
 }

--- a/src/main/kotlin/repository/SpotRepository.kt
+++ b/src/main/kotlin/repository/SpotRepository.kt
@@ -1,0 +1,64 @@
+package parkflex.repository
+
+import parkflex.db.SpotEntity
+
+object SpotRepository {
+    /**
+     * ADT representing type of spot during layout parsing.
+     */
+    private sealed interface LayoutToken : Comparable<LayoutToken> {
+        object Gate : LayoutToken
+        object Empty : LayoutToken
+        data class Numbered(val x: Long) : LayoutToken
+
+        override fun compareTo(other: LayoutToken): Int {
+            val getWeight = { token: LayoutToken ->
+                when (token) {
+                    Empty -> Int.MAX_VALUE
+                    Gate -> Int.MAX_VALUE
+                    is Numbered -> token.x.toInt() // bite me
+                }
+            }
+
+            return getWeight(this) - getWeight(other);
+        }
+    }
+
+    /**
+     * Populates the `spots` table according to the provided layout.
+     */
+    fun populate(layout: String): Result<Unit> = runCatching {
+        layout
+            .split("\n")
+            .flatMap { it.split("""[ \t]+""".toRegex()) }
+            .map {
+                when (it) {
+                    "G" -> LayoutToken.Gate
+                    "." -> LayoutToken.Empty
+                    else -> LayoutToken.Numbered(it.toLong())
+                }
+            }
+            .withIndex()
+            .sortedBy { it.value }
+            .fold(0L) { lastId, token ->
+                val entity = when (token.value) {
+                    LayoutToken.Gate -> SpotEntity.new(lastId + 1) {
+                        role = "gate"
+                        displayOrder = token.index
+                    }
+
+                    LayoutToken.Empty -> SpotEntity.new(lastId + 1) {
+                        role = "blank"
+                        displayOrder = token.index
+                    }
+
+                    is LayoutToken.Numbered -> SpotEntity.new((token.value as LayoutToken.Numbered).x) {
+                        role = "normal"
+                        displayOrder = token.index
+                    }
+                }
+
+                entity.id.value
+            }
+    }
+}


### PR DESCRIPTION
Done to align for changes made in `parking-view` frontend (#41) .

* Add `displayOrder` col
* Add default layout parameter
* Add automatic population of the spots table