### PR TITLE
Add deployment automation

### DIFF
--- a/.github/workflows/trigger-deployment.yml
+++ b/.github/workflows/trigger-deployment.yml
@@ -1,0 +1,28 @@
+name: Notify Deployment Repo
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  trigger-deployment-sync:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Trigger deployment repo sync
+        run: |
+          curl -X POST \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: token ${{ secrets.DEPLOYMENT_TRIGGER_TOKEN }}" \
+            https://api.github.com/repos/ParkFlex/parkflex-deployment/dispatches \
+            -d '{"event_type":"main-updated"}'
+      
+      - name: Summary
+        run: |
+          echo "## 🚀 Deployment Triggered" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Notified parkflex-deployment to sync and rebuild" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Commit:** ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Author:** ${{ github.actor }}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Opis

Dodaje automatyczną synchronizację z repo deployment po pushu do main.

## Co to robi

- Po każdym pushu do , triggeruje workflow w 
- Deployment repo automatycznie pobiera najnowszy kod, builduje frontend i tworzy obrazy Docker

## Wymagane kroki

 **UWAGA**: Przed mergem tego PR, musisz:

1. **Utworzyć Personal Access Token**:
   - Idź do: https://github.com/settings/tokens/new
   - Name: `Deployment Trigger Token`
   - Scopes: Zaznacz `repo` (full control)
   - Generate i SKOPIUJ token

2. **Dodać secret do tego repo**:
   - Idź do: https://github.com/ParkFlex/parkflex/settings/secrets/actions
   - New repository secret
   - Name: `DEPLOYMENT_TRIGGER_TOKEN`
   - Value: [wklej token]

## Nowe repo

Utworzone: https://github.com/ParkFlex/parkflex-deployment

Zawiera:
- Docker Compose z MariaDB
- Multi-stage Dockerfiles
- Auto-sync workflow
- Dokumentację