### PR TITLE
Fix issue #82: Add life parameter to toasts to auto-dismiss after 3 seconds

### DIFF
--- a/frontend/src/hooks/useGetSpots.tsx
+++ b/frontend/src/hooks/useGetSpots.tsx
@@ -50,6 +50,7 @@ export const useGetSpots = (
             toast.current?.show(
                 {
                     sticky: false,
+                    life: 3000,
                     summary: summary,
                     detail: detail,
                     severity: "error",

--- a/frontend/src/pages/Parking.tsx
+++ b/frontend/src/pages/Parking.tsx
@@ -34,6 +34,7 @@ export function ParkingPage() {
             msgs.current?.show([
                 {
                     sticky: false,
+                    life: 3000,
                     severity: "warn",
                     summary: "Uwaga",
                     detail: "Najpierw wybierz miejsce.",
@@ -58,6 +59,7 @@ export function ParkingPage() {
             msgs.current?.show([
                 {
                     sticky: false,
+                    life: 3000,
                     severity: "success",
                     summary: "Sukces",
                     detail: resp.message,
@@ -72,6 +74,7 @@ export function ParkingPage() {
             msgs.current?.show([
                 {
                     sticky: false,
+                    life: 3000,
                     severity: "error",
                     summary: "Błąd",
                     detail: msg,


### PR DESCRIPTION
## Problem
Toast notifications after creating a new reservation stayed on the screen indefinitely, hiding the selection status and making the submit button unclickable.

## Solution
Added `life: 3000` parameter (3 seconds) to all toast notifications:
- Warning toast when no spot is selected
- Success toast after creating a reservation
- Error toast when reservation fails
- Error toast when fetching spots fails

## Changes
- **frontend/src/pages/Parking.tsx**: Added `life: 3000` to 3 toast notifications
- **frontend/src/hooks/useGetSpots.tsx**: Added `life: 3000` to error toast

## Closes
Closes #82