### PR TITLE
Fix issue #85: Add missing return@post after BadRequest in spot role validation

### DIFF
--- a/src/main/kotlin/routes/reservationRoutes.kt
+++ b/src/main/kotlin/routes/reservationRoutes.kt
@@ -98,6 +98,7 @@ fun Route.reservationRoutes() {
                     context
                 )
             )
+            return@post
         }
 
         // Parse start time


### PR DESCRIPTION
## Problem
In reservationRoutes.kt, when a spot has a role other than "normal", the application calls `call.respond` with a 400 BadRequest but does not terminate the handler. This causes the handler to continue executing, potentially leading to unexpected behavior.

## Solution
Added `return@post` after the `call.respond` statement in the spot role validation check, consistent with the pattern used in other validation checks in the same file (e.g., line 90 for the NotFound check).

## Changes
- **src/main/kotlin/routes/reservationRoutes.kt**: Added `return@post` after BadRequest response when spot role is not 'normal' (line 101)

## Testing
The fix follows the same pattern as the existing validation checks in the file and prevents the handler from continuing after sending an error response.

## Closes
Closes #85