### PR TITLE
Add Dokka documentation generation task and improve KDoc comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,42 @@
 - [Intellij Idea](https://www.jetbrains.com/idea/) - Ultimate jest za darmo dla studentów
 - [VSCode](https://nodejs.org/en/download/)
 - [NPM i Node.js](https://nodejs.org/en/download/) - Na Windowsie wybieramy prebuilt Windows Installer (.msi). Potrzebne do frontendu
+
+---
+
+## 📚 Dokumentacja
+
+### Generowanie dokumentacji Dokka
+
+Projekt używa [Dokka](https://kotlinlang.org/docs/dokka-introduction.html) do automatycznego generowania dokumentacji z komentarzy KDoc w kodzie.
+
+**Jak wygenerować dokumentację:**
+
+```bash
+./gradlew dokkaDoc
+```
+
+Dokumentacja zostanie wygenerowana w formacie HTML i będzie dostępna w:
+```
+build/dokka/html/index.html
+```
+
+**Przykład dokumentacji funkcji:**
+
+```kotlin
+/**
+ * Oblicza pole prostokąta na podstawie podanych wymiarów.
+ * 
+ * @param dlugosc Długość prostokąta w jednostkach (musi być większa od 0)
+ * @param szerokosc Szerokość prostokąta w jednostkach (musi być większa od 0)
+ * @return Pole prostokąta jako wartość Double
+ * @throws IllegalArgumentException jeśli którykolwiek z wymiarów jest mniejszy lub równy 0
+ */
+fun obliczPoleProstokata(dlugosc: Double, szerokosc: Double): Double {
+    require(dlugosc > 0) { "Długość musi być większa od 0" }
+    require(szerokosc > 0) { "Szerokość musi być większa od 0" }
+    return dlugosc * szerokosc
+}
+```
+
+Więcej informacji o formacie KDoc: [Kotlin Docs - KDoc](https://kotlinlang.org/docs/kotlin-doc.html)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -98,6 +98,22 @@ tasks.register("apiDoc") {
     }
 }
 
+tasks.register("dokkaDoc") {
+    group = "documentation"
+    description = "Generuje dokumentację Dokka w formacie HTML"
+    
+    dependsOn("dokkaGeneratePublicationHtml")
+    
+    doLast {
+        val dokkaOutputDir = project.layout.buildDirectory.dir("dokka/html").get().asFile
+        println("=".repeat(60))
+        println("Dokumentacja Dokka wygenerowana pomyślnie!")
+        println("Lokalizacja: ${dokkaOutputDir.absolutePath}")
+        println("Otwórz plik: ${dokkaOutputDir.absolutePath}/index.html")
+        println("=".repeat(60))
+    }
+}
+
 val npmBin =
     if (Os.isFamily(Os.FAMILY_WINDOWS)) "npm.cmd"
     else "npm"


### PR DESCRIPTION
- Add dokkaDoc task in build.gradle.kts for generating HTML documentation
- Add mock documentation for getRealIp() function
- Update README.md with Dokka usage instructions and example
- Configure task to use Dokka V2 (dokkaGeneratePublicationHtml)