### PR TITLE
fix: Use Authorization token for /historyEntry instead userId query param

### DIFF
--- a/frontend/src/hooks/useHistoryEntries.ts
+++ b/frontend/src/hooks/useHistoryEntries.ts
@@ -1,29 +1,26 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect } from "react";
 
-import { useAxios } from './useAxios';
+import { useAxios } from "./useAxios";
 import type { HistoryEntry } from "../models/history/HistoryEntry.tsx";
 import { isAxiosError } from "axios";
 
 /**
  * Hook do pobierania historii rezerwacji użytkownika.
- * 
+ *
  * @returns Obiekt zawierający posortowane wpisy historii
- * 
+ *
  * @remarks
- * TODO: userId jest zahardkodowane na wartość 2.
- * Należy pobierać prawdziwe ID zalogowanego użytkownika z kontekstu/stanu.
- * 
  * Hook automatycznie:
  * 1. Pobiera dane z GET /api/historyEntry?userId=2
  * 2. Konwertuje stringi dat na obiekty Date
  * 3. Sortuje wpisy od najnowszych do najstarszych
  * 4. Obsługuje błędy (w tym anulowanie zapytań)
- * 
+ *
  * @example
  * ```tsx
  * function HistoryPage() {
  *   const { entries } = useHistoryEntries();
- *   
+ *
  *   return (
  *     <div>
  *       {entries.map(entry => (
@@ -40,33 +37,26 @@ export const useHistoryEntries = () => {
 
     useEffect(() => {
         const fetchEntries = async () => {
-            const userId = 2;
-
-            // const json = {
-            //     "userId": userId
-            // }
-            // ===
-            // const json = {userId}
-
             try {
-                const resp = await axios.get<Array<HistoryEntry>>(
-                    `/historyEntry`,
-                    { params: { userId } }
-                );
+                const resp =
+                    await axios.get<Array<HistoryEntry>>(`/historyEntry`);
                 for (const respElement of resp.data) {
                     respElement.startTime = new Date(respElement.startTime);
                 }
                 setEntries(resp.data);
-
             } catch (err: unknown) {
                 if (isAxiosError(err)) {
-                    if (err && (err.code === 'ERR_CANCELED' || err.name === 'CanceledError')) {
+                    if (
+                        err &&
+                        (err.code === "ERR_CANCELED" ||
+                            err.name === "CanceledError")
+                    ) {
                         return;
                     }
-                    console.error('Error fetching history entries', err);
+                    console.error("Error fetching history entries", err);
                     setEntries([]);
                 } else {
-                    console.error('Unexpected error occurred', err);
+                    console.error("Unexpected error occurred", err);
                 }
             }
         };

--- a/src/main/kotlin/config/AppConfig.kt
+++ b/src/main/kotlin/config/AppConfig.kt
@@ -148,8 +148,8 @@ class AppConfig : Config {
         mail to passwd
     }
 
-    val jwtIssuer: String = getenvWrapped("PARKFLEX_JWT_ISSUER") ?: "parkflex"
-    val jwtSecret: String = getenvWrapped("PARKFLEX_JWT_SECRET") ?: "#!@secret!31#$"
-    val jwtExpiresMs: Long =
+    override val jwtIssuer: String = getenvWrapped("PARKFLEX_JWT_ISSUER") ?: "parkflex"
+    override val jwtSecret: String = getenvWrapped("PARKFLEX_JWT_SECRET") ?: "#!@secret!31#$"
+    override val jwtExpiresMs: Long =
         getenvWrapped("PARKFLEX_JWT_EXPIRES_MS")?.toLong() ?: (7 * 24 * 3600 * 1000L)
 }

--- a/src/main/kotlin/config/Config.kt
+++ b/src/main/kotlin/config/Config.kt
@@ -24,6 +24,11 @@ interface Config {
     
     /** Admin credentials as (email, password) pair */
     val adminData: Pair<String, String>
+
+    /** JWT Configuration */
+    val jwtIssuer: String
+    val jwtSecret: String
+    val jwtExpiresMs: Long
 }
 
 /**

--- a/src/main/kotlin/config/TestConfig.kt
+++ b/src/main/kotlin/config/TestConfig.kt
@@ -13,4 +13,7 @@ object TestConfig : Config {
     override val ENABLE_H2_SOCKETS: Boolean = false
     override val CALL_LOG_LEVEL: Level = Level.ERROR
     override val adminData: Pair<String, String> = "admin" to ""
+    override val jwtIssuer: String = "parkflex"
+    override val jwtSecret: String = "#!@secret!31#$"
+    override val jwtExpiresMs: Long = 7 * 24 * 3600 * 1000L
 }

--- a/src/main/kotlin/main.kt
+++ b/src/main/kotlin/main.kt
@@ -46,5 +46,7 @@ suspend fun Application.configureTest(db: Database? = null) {
     configureDB(TestConfig, db)
     configureJSON()
     configureSSE()
+    configureStatusPages()
+    configureAuth(TestConfig)
     configureRouting()
 }

--- a/src/main/kotlin/modules/configureAuth.kt
+++ b/src/main/kotlin/modules/configureAuth.kt
@@ -8,7 +8,7 @@ import io.ktor.http.*
 import io.ktor.server.response.respondText
 import parkflex.models.ApiErrorModel
 
-fun Application.configureAuth(config: parkflex.config.AppConfig) {
+fun Application.configureAuth(config: parkflex.config.Config) {
     JwtRepository.init(config.jwtSecret, config.jwtIssuer, config.jwtExpiresMs)
 
     install(Authentication) {

--- a/src/main/kotlin/routes/apiRoutes.kt
+++ b/src/main/kotlin/routes/apiRoutes.kt
@@ -47,7 +47,9 @@ fun Route.apiRoutes() {
     }
 
     route("/historyEntry") {
-        historyRoutes()
+        authenticate {
+            historyRoutes()
+        }
     }
 
     route("/reservation") {

--- a/src/main/kotlin/routes/history/historyRoutes.kt
+++ b/src/main/kotlin/routes/history/historyRoutes.kt
@@ -8,46 +8,37 @@ import parkflex.db.UserEntity
 import parkflex.models.ApiErrorModel
 import parkflex.models.history.HistoryEntry
 import parkflex.runDB
+import parkflex.utils.currentUserEntity
 
 /**
  * Routes for user reservation history.
- * 
- * Endpoint: GET /api/historyEntry?userId={userId}
+ *
+ * Endpoint: GET /api/historyEntry
  * Retrieves reservation history for a specific user.
  */
 fun Route.historyRoutes() {
     get {
-        val id = call.queryParameters["userId"]
-        if (id == null) {
+        val user = call.currentUserEntity()
+        if (user == null) {
             call.respond(
-                status = HttpStatusCode.UnprocessableEntity,
-                message = ApiErrorModel("No ID found", "/api/history GET")
+                status = HttpStatusCode.NotFound,
+                message = ApiErrorModel("Nie znaleziono użytkownika", "/api/history GET"),
             )
-        } else {
-            val idLong = id.toLong()
-            val user = runDB { UserEntity.findById(idLong) }
-            if (user == null) {
-                call.respond(
-                    status = HttpStatusCode.NotFound,
-                    message = ApiErrorModel("User not found", "/api/history GET")
-                )
-            }
+            return@get
+        }
 
-            var historyList: List<HistoryEntry> = listOf()
+        val historyList: List<HistoryEntry> =
             runDB {
-                val reservations = user!!.reservations.toList()
-                for (reservation in reservations) {
-                    val status: String
-                    if (reservation.hasPenalty) {
-                        status = "penalty"
-                    } else {
-                        status = "ok"
-                    }
-                    val entry = HistoryEntry(reservation.start, reservation.duration, status, reservation.spot.id.value)
-                    historyList += entry
+                user.reservations.map { reservation ->
+                    HistoryEntry(
+                        startTime = reservation.start,
+                        durationMin = reservation.duration,
+                        status = if (reservation.hasPenalty) "penalty" else "ok",
+                        spot = reservation.spot.id.value,
+                    )
                 }
             }
-            call.respond(historyList)
-        }
+
+        call.respond(historyList)
     }
 }

--- a/src/test/kotlin/testingClient.kt
+++ b/src/test/kotlin/testingClient.kt
@@ -4,11 +4,14 @@ import io.ktor.server.testing.ApplicationTestBuilder
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.*
 import parkflex.LocalDateTimeSerializer
+import parkflex.repository.JwtRepository
+import parkflex.config.TestConfig
 
 /**
  * Shared client builder for unit tests
  */
 fun ApplicationTestBuilder.testingClient() = createClient {
+    JwtRepository.init(TestConfig.jwtSecret, TestConfig.jwtIssuer, TestConfig.jwtExpiresMs)
     install(ContentNegotiation) {
         json(
             Json {


### PR DESCRIPTION
Resolves: https://github.com/ParkFlex/parkflex/issues/123
I've modified `historyEntry` to use jwt instead of userId query paramets, and also I've updated test suite for that endpoint.
<img width="559" height="79" alt="image" src="https://github.com/user-attachments/assets/e3597a72-1d03-4615-8361-8544be80f091" />
